### PR TITLE
Reorganize repository structure

### DIFF
--- a/abci_proxy/abci_proxy.go
+++ b/abci_proxy/abci_proxy.go
@@ -2,14 +2,14 @@ package main
 
 import (
 	"flag"
-	"os"
 	"fmt"
+	"os"
 
+	"github.com/multiverseHQ/abci_proxy"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 
 	abcicli "github.com/tendermint/abci/client"
-	"github.com/MultiverseHQ/abci_proxy/proxy"
 	"github.com/tendermint/abci/server"
 )
 
@@ -31,7 +31,7 @@ func main() {
 	next := abcicli.NewSocketClient(*proxyPtr, true)
 
 	// Start the listener
-	srv, err := server.NewServer(*addrPtr, *abciPtr, proxy.NewProxyApp(next, []byte("echo")))
+	srv, err := server.NewServer(*addrPtr, *abciPtr, abciproxy.NewProxyApp(next, []byte("echo")))
 	if err != nil {
 		logger.Error(err.Error())
 		os.Exit(1)

--- a/proxy.go
+++ b/proxy.go
@@ -1,4 +1,4 @@
-package proxy
+package abciproxy
 
 import (
 	"bytes"


### PR DESCRIPTION
* Uses the more golang idiomatic organization of <root> / business logic
library / executable structure.
*  Renames the lib proxy -> abciproxy less confusing names to avoid name
   clash with other golang packages
* Makes the files pass `go fmt`