### PR TITLE
Adds Proxy.ChangeValidators() to change validator set concurrently

### DIFF
--- a/abci_proxy/abci_proxy.go
+++ b/abci_proxy/abci_proxy.go
@@ -5,11 +5,11 @@ import (
 	"os"
 
 	"github.com/MultiverseHQ/abci_proxy"
-	cmn "github.com/tendermint/tmlibs/common"
 	tmlog "github.com/tendermint/tmlibs/log"
 
 	abcicli "github.com/tendermint/abci/client"
 	"github.com/tendermint/abci/server"
+	cmn "github.com/tendermint/tmlibs/common"
 )
 
 var logger tmlog.Logger
@@ -43,8 +43,9 @@ func Execute() error {
 		return err
 	}
 
+	proxy := abciproxy.NewProxyApp(next)
 	// Start the listener
-	srv, err := server.NewServer(opts.Address, opts.ABCIType, abciproxy.NewProxyApp(next, []byte("echo")))
+	srv, err := server.NewServer(opts.Address, opts.ABCIType, proxy)
 	if err != nil {
 		return err
 	}
@@ -52,6 +53,8 @@ func Execute() error {
 	if _, err := srv.Start(); err != nil {
 		return err
 	}
+
+	proxy.StartRPCServer(opts.RPCAddress)
 
 	// Wait forever
 	cmn.TrapSignal(func() {

--- a/abci_proxy/options.go
+++ b/abci_proxy/options.go
@@ -7,12 +7,14 @@ type options struct {
 	ABCIType   string
 	AppAddress string
 	Verbose    bool
+	RPCAddress string
 }
 
 func ParseOptions() options {
 	var opts options
 
 	flag.StringVar(&opts.Address, "addr", "tcp://0.0.0.0:46658", "Listen address for tendermind node")
+	flag.StringVar(&opts.Address, "rpc", "tcp://0.0.0.0:46660", "listen address for rcp")
 	flag.StringVar(&opts.ABCIType, "abci", "socket", "socket | grpc")
 	flag.StringVar(&opts.AppAddress, "proxy", "tcp://0.0.0.0:46659", "Address of next ABCI app")
 	flag.BoolVar(&opts.Verbose, "verbose", false, "verbose output")

--- a/bc_node_test.go
+++ b/bc_node_test.go
@@ -47,12 +47,12 @@ const ProxyAppPortStart int = 50000
 const RPCPortStart int = 50100
 const P2PPortStart int = 50200
 const AppPortStart int = 50300
+const RPCProxyStart int = 50400
 
 // NewBCNode instantiate a new node for testing ID should be unique
 // between 0 and 99, rootDir is the path to a directory where all
-// config data will be stored. genesisPath is the path to the genesis
-// file to use
-func NewBCNode(ID BCNodeID, genesisPath string, rootDir string) (*BCNode, error) {
+// config data will be stored.
+func NewBCNode(ID BCNodeID, rootDir string) (*BCNode, error) {
 	if ID > MaxBCNodeID {
 		return nil, fmt.Errorf("Maximum  BCNodeID for test is %d, got %d", MaxBCNodeID, ID)
 	}
@@ -116,8 +116,6 @@ func (n *BCNode) Start(peers []*BCNode) error {
 	if _, err := n.proxyService.Start(); err != nil {
 		return err
 	}
-
-	//generate the list of peers
 
 	//start tendermint node
 	n.tmNodeCmd = exec.Command("tendermint", "node",
@@ -196,6 +194,10 @@ func (n *BCNode) P2PPort() int {
 
 func (n *BCNode) AppPort() int {
 	return AppPortStart + int(n.ID)
+}
+
+func (n *BCNode) RPCProxyPort() int {
+	return RPCProxyStart + int(n.ID)
 }
 
 func (n *BCNode) WorkingDir() string {

--- a/bc_node_test.go
+++ b/bc_node_test.go
@@ -1,0 +1,52 @@
+package abciproxy
+
+import "fmt"
+
+type BCNodeID int
+
+// A BCNode consist of a tendermint node, its application and the
+// proxy running between those This object is here to maintain sane
+// configuration and overall start/stop function for testing purpose
+// on a single computer
+type BCNode struct {
+	ID BCNodeID
+}
+
+const MaxBCNodeID BCNodeID = 99
+
+const ProxyAppPortStart int = 50000
+const RPCPortStart int = 50100
+const P2PPortStart int = 50200
+const AppPortStart int = 50300
+
+func NewBCNode(ID BCNodeID, genesisPath string, homeDir string) (*BCNode, error) {
+	if ID > MaxBCNodeID {
+		return nil, fmt.Errorf("Maximum  BCNodeID for test is %d, got %d", MaxBCNodeID, ID)
+	}
+
+	return nil, NotYetImplemented()
+}
+
+func (*BCNode) Start() error {
+	return NotYetImplemented()
+}
+
+func (*BCNode) Stop() error {
+	return NotYetImplemented()
+}
+
+func (n *BCNode) ProxyAppPort() int {
+	return ProxyAppPortStart + int(n.ID)
+}
+
+func (n *BCNode) RPCPort() int {
+	return RPCPortStart + int(n.ID)
+}
+
+func (n *BCNode) P2PPort() int {
+	return RPCPortStart + int(n.ID)
+}
+
+func (n *BCNode) AppPort() int {
+	return AppPortStart + int(n.ID)
+}

--- a/bc_node_test.go
+++ b/bc_node_test.go
@@ -104,7 +104,7 @@ func (n *BCNode) Start(peers []*BCNode) error {
 		return err
 	}
 
-	n.proxy = NewProxyApp(n.appClient, []byte("echo"))
+	n.proxy = NewProxyApp(n.appClient)
 	n.proxyService, err = server.NewServer(fmt.Sprintf("tcp://127.0.0.1:%d", n.ProxyAppPort()),
 		"socket",
 		n.proxy)

--- a/bc_node_test.go
+++ b/bc_node_test.go
@@ -91,7 +91,7 @@ func (n *BCNode) Start() error {
 		return err
 	}
 	//let time to the app to start
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	//start proxy
 	n.appClient = abcicli.NewSocketClient(fmt.Sprintf("tcp://127.0.0.1:%d", n.AppPort()), true)

--- a/proxy.go
+++ b/proxy.go
@@ -94,7 +94,7 @@ func (app *ProxyApplication) BeginBlock(hash []byte, header *types.Header) {
 	_ = app.next.BeginBlockSync(hash, header)
 }
 
-func (app *ProxyApplication) ChangeValidator(newValidators []*types.Validator, targetHeight uint64) error {
+func (app *ProxyApplication) ChangeValidators(newValidators []*types.Validator, targetHeight uint64) error {
 	app.logger.Debug("received new validator set",
 		"validators", newValidators,
 		"targetHeight", targetHeight)
@@ -164,11 +164,11 @@ type CurrentHeightResult struct {
 type ChangeValidatorsResult struct {
 }
 
-func (app *ProxyApplication) StartRPCServerr(rcpAddress string) {
+func (app *ProxyApplication) StartRPCServerr(rpcAddress string) {
 
 	var routes = map[string]*rpcserver.RPCFunc{
 		"change_validators": rpcserver.NewRPCFunc(func(validators []*types.Validator, scheduledHeight uint64) (*ChangeValidatorsResult, error) {
-			err := app.ChangeValidator(validators, scheduledHeight)
+			err := app.ChangeValidators(validators, scheduledHeight)
 			return &ChangeValidatorsResult{}, err
 		}, "validators,scheduled_height"),
 		"current_height": rpcserver.NewRPCFunc(func() (*CurrentHeightResult, error) {
@@ -183,8 +183,9 @@ func (app *ProxyApplication) StartRPCServerr(rcpAddress string) {
 	mux.HandleFunc("/websocket/endpoint", wm.WebsocketHandler)
 
 	go func() {
-		logger.Info("start RPC server", "address", rpcAddress)
-		_, err := rpcserver.StartHTTPServer(rpcAddress, mux, logger)
+		app.
+			logger.Info("start RPC server", "address", rpcAddress)
+		_, err := rpcserver.StartHTTPServer(rpcAddress, mux, app.logger)
 		if err != nil {
 			panic(err)
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -96,8 +96,10 @@ func (app *ProxyApplication) BeginBlock(hash []byte, header *types.Header) {
 	_ = app.next.BeginBlockSync(hash, header)
 }
 
-func (app *ProxyApplication) ChangeValidator(newValidators []*types.Validator) {
-	app.logger.Debug("received new validator set", "validators", newValidators)
+func (app *ProxyApplication) ChangeValidator(newValidators []*types.Validator, targetHeight uint64) {
+	app.logger.Debug("received new validator set",
+		"validators", newValidators,
+		"targetHeight", targetHeight)
 	app.newValidators <- newValidators
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -2,11 +2,9 @@ package abciproxy
 
 import (
 	"fmt"
-	"net/http"
 
 	abcicli "github.com/tendermint/abci/client"
 	"github.com/tendermint/abci/types"
-	"github.com/tendermint/tendermint/rpc/lib/server"
 	tmlog "github.com/tendermint/tmlibs/log"
 )
 
@@ -155,40 +153,4 @@ func (app *ProxyApplication) EndBlock(height uint64) (resEndBlock types.Response
 	}
 
 	return res
-}
-
-type CurrentHeightResult struct {
-	Height uint64 `json:"height"`
-}
-
-type ChangeValidatorsResult struct {
-}
-
-func (app *ProxyApplication) StartRPCServerr(rpcAddress string) {
-
-	var routes = map[string]*rpcserver.RPCFunc{
-		"change_validators": rpcserver.NewRPCFunc(func(validators []*types.Validator, scheduledHeight uint64) (*ChangeValidatorsResult, error) {
-			err := app.ChangeValidators(validators, scheduledHeight)
-			return &ChangeValidatorsResult{}, err
-		}, "validators,scheduled_height"),
-		"current_height": rpcserver.NewRPCFunc(func() (*CurrentHeightResult, error) {
-			return &CurrentHeightResult{Height: app.lastHeight}, nil
-		}, ""),
-	}
-
-	mux := http.NewServeMux()
-	rpcserver.RegisterRPCFuncs(mux, routes, app.logger)
-	wm := rpcserver.NewWebsocketManager(routes, nil)
-	wm.SetLogger(app.logger)
-	mux.HandleFunc("/websocket/endpoint", wm.WebsocketHandler)
-
-	go func() {
-		app.
-			logger.Info("start RPC server", "address", rpcAddress)
-		_, err := rpcserver.StartHTTPServer(rpcAddress, mux, app.logger)
-		if err != nil {
-			panic(err)
-		}
-	}()
-
 }

--- a/rpc.go
+++ b/rpc.go
@@ -1,0 +1,44 @@
+package abciproxy
+
+import (
+	"net/http"
+
+	"github.com/tendermint/abci/types"
+	"github.com/tendermint/tendermint/rpc/lib/server"
+)
+
+type CurrentHeightResult struct {
+	Height uint64 `json:"height"`
+}
+
+type ChangeValidatorsResult struct {
+}
+
+func (app *ProxyApplication) StartRPCServerr(rpcAddress string) {
+
+	var routes = map[string]*rpcserver.RPCFunc{
+		"change_validators": rpcserver.NewRPCFunc(func(validators []*types.Validator, scheduledHeight uint64) (*ChangeValidatorsResult, error) {
+			err := app.ChangeValidators(validators, scheduledHeight)
+			return &ChangeValidatorsResult{}, err
+		}, "validators,scheduled_height"),
+		"current_height": rpcserver.NewRPCFunc(func() (*CurrentHeightResult, error) {
+			return &CurrentHeightResult{Height: app.lastHeight}, nil
+		}, ""),
+	}
+
+	mux := http.NewServeMux()
+	rpcserver.RegisterRPCFuncs(mux, routes, app.logger)
+	wm := rpcserver.NewWebsocketManager(routes, nil)
+	wm.SetLogger(app.logger)
+	mux.HandleFunc("/websocket/endpoint", wm.WebsocketHandler)
+
+	go func() {
+		app.
+			logger.Info("start RPC server", "address", rpcAddress)
+		_, err := rpcserver.StartHTTPServer(rpcAddress, mux, app.logger)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+}

--- a/rpc.go
+++ b/rpc.go
@@ -14,7 +14,7 @@ type CurrentHeightResult struct {
 type ChangeValidatorsResult struct {
 }
 
-func (app *ProxyApplication) StartRPCServerr(rpcAddress string) {
+func (app *ProxyApplication) StartRPCServer(rpcAddress string) {
 
 	var routes = map[string]*rpcserver.RPCFunc{
 		"change_validators": rpcserver.NewRPCFunc(func(validators []*types.Validator, scheduledHeight uint64) (*ChangeValidatorsResult, error) {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1,0 +1,93 @@
+package abciproxy
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/tendermint/abci/types"
+	"github.com/tendermint/tendermint/rpc/lib/client"
+	tmtypes "github.com/tendermint/tendermint/types"
+
+	. "gopkg.in/check.v1"
+)
+
+type RPCSuite struct {
+	testHome    string
+	node        *BCNode
+	genesisFile *tmtypes.GenesisDoc
+
+	cli *rpcclient.JSONRPCClient
+}
+
+var _ = Suite(&RPCSuite{})
+
+func (s *RPCSuite) SetUpSuite(c *C) {
+	var err error
+
+	s.testHome, err = ioutil.TempDir("", "abci_proxy_test")
+	c.Assert(err, IsNil, Commentf("Cannot create tempdir: %s", err))
+
+	s.node, err = NewBCNode(0, s.testHome)
+	c.Assert(err, IsNil, Commentf("Cannot create node: %s", err))
+
+	err = s.node.Start(nil)
+	c.Assert(err, IsNil)
+
+	//only in this suite please, as we cannot stop it
+	address := fmt.Sprintf("127.0.0.1:%d", s.node.RPCProxyPort())
+	s.node.proxy.StartRPCServerr("tcp://" + address)
+
+	s.genesisFile, err = tmtypes.GenesisDocFromFile(filepath.Join(s.node.WorkingDir(), "genesis.json"))
+	c.Assert(err, IsNil)
+
+	s.cli = rpcclient.NewJSONRPCClient("http://" + address)
+}
+
+func (s *RPCSuite) TearDownSuite(c *C) {
+	err := s.node.Stop()
+	c.Assert(err, IsNil)
+
+	err = os.RemoveAll(s.testHome)
+	c.Assert(err, IsNil)
+
+	os.Remove(s.testHome)
+}
+
+func (s *RPCSuite) TestCanFetchCurrentHeight(c *C) {
+	//wait for at least one call
+	s.node.testApplication.EndBlockCalls.ExpectCall(1)
+	s.node.testApplication.EndBlockCalls.WaitForExpected()
+
+	res := new(CurrentHeightResult)
+	_, err := s.cli.Call("current_height", map[string]interface{}{}, res)
+	c.Assert(err, IsNil)
+	c.Check(res.Height, Equals, s.node.proxy.lastHeight)
+
+}
+
+func (s *RPCSuite) TestCanChangeValidators(c *C) {
+	s.node.testApplication.EndBlockCalls.ExpectCall(2)
+	s.node.testApplication.EndBlockCalls.WaitForExpected()
+
+	// change should be in the future
+	res := new(ChangeValidatorsResult)
+	_, err := s.cli.Call("change_validators", map[string]interface{}{
+		"scheduled_height": s.node.proxy.lastHeight - 1,
+		"validators":       []*types.Validator{},
+	}, res)
+	c.Check(err, ErrorMatches, `Response error: Could not schedule for a block height back in time.*`)
+
+	_, err = s.cli.Call("change_validators", map[string]interface{}{
+		"scheduled_height": s.node.proxy.lastHeight + 5,
+		"validators": []*types.Validator{
+			&types.Validator{
+				PubKey: s.genesisFile.Validators[0].PubKey.Bytes(),
+				Power:  20,
+			},
+		},
+	}, res)
+	c.Check(err, IsNil)
+
+}

--- a/test_application_test.go
+++ b/test_application_test.go
@@ -1,0 +1,113 @@
+package abciproxy
+
+import (
+	"encoding/binary"
+
+	"github.com/tendermint/abci/types"
+	cmn "github.com/tendermint/tmlibs/common"
+)
+
+// TestApplication is to be used in our test to actually test that our
+// application is going from observer state to validator state. Its
+// simply a counter, but we register all calls to its method.
+type TestApplication struct {
+	types.BaseApplication
+
+	hashCount int
+	txCount   int
+	serial    bool
+
+	InfoCalls      InterceptedMethod
+	CommitCalls    InterceptedMethod
+	SetOptionCalls InterceptedMethod
+	DeliverTxCalls InterceptedMethod
+	CheckTxCalls   InterceptedMethod
+	QueryCalls     InterceptedMethod
+	EndBlockCalls  InterceptedMethod
+}
+
+func NewTestApplication(serial bool) *TestApplication {
+	return &TestApplication{
+		serial:         serial,
+		InfoCalls:      NewInterceptedMethod("Info"),
+		CommitCalls:    NewInterceptedMethod("Commit"),
+		SetOptionCalls: NewInterceptedMethod("SetOption"),
+		DeliverTxCalls: NewInterceptedMethod("DeliverTx"),
+		CheckTxCalls:   NewInterceptedMethod("CheckTx"),
+		QueryCalls:     NewInterceptedMethod("Query"),
+		EndBlockCalls:  NewInterceptedMethod("EndBlock"),
+	}
+}
+
+func (app *TestApplication) Info() types.ResponseInfo {
+	app.InfoCalls.Notify()
+	return types.ResponseInfo{Data: cmn.Fmt("{\"hashes\":%v,\"txs\":%v}", app.hashCount, app.txCount)}
+}
+
+func (app *TestApplication) SetOption(key string, value string) (log string) {
+	app.SetOptionCalls.Notify(key, value)
+	if key == "serial" && value == "on" {
+		app.serial = true
+	}
+	return ""
+}
+
+func (app *TestApplication) DeliverTx(tx []byte) types.Result {
+	app.DeliverTxCalls.Notify(tx)
+	if app.serial {
+		if len(tx) > 8 {
+			return types.ErrEncodingError.SetLog(cmn.Fmt("Max tx size is 8 bytes, got %d", len(tx)))
+		}
+		tx8 := make([]byte, 8)
+		copy(tx8[len(tx8)-len(tx):], tx)
+		txValue := binary.BigEndian.Uint64(tx8)
+		if txValue != uint64(app.txCount) {
+			return types.ErrBadNonce.SetLog(cmn.Fmt("Invalid nonce. Expected %v, got %v", app.txCount, txValue))
+		}
+	}
+	app.txCount++
+	return types.OK
+}
+
+func (app *TestApplication) CheckTx(tx []byte) types.Result {
+	if app.serial {
+		if len(tx) > 8 {
+			return types.ErrEncodingError.SetLog(cmn.Fmt("Max tx size is 8 bytes, got %d", len(tx)))
+		}
+		tx8 := make([]byte, 8)
+		copy(tx8[len(tx8)-len(tx):], tx)
+		txValue := binary.BigEndian.Uint64(tx8)
+		if txValue < uint64(app.txCount) {
+			return types.ErrBadNonce.SetLog(cmn.Fmt("Invalid nonce. Expected >= %v, got %v", app.txCount, txValue))
+		}
+	}
+	return types.OK
+}
+
+func (app *TestApplication) Commit() types.Result {
+	app.CommitCalls.Notify()
+	app.hashCount++
+	if app.txCount == 0 {
+		return types.OK
+	}
+	hash := make([]byte, 8)
+	binary.BigEndian.PutUint64(hash, uint64(app.txCount))
+	return types.NewResultOK(hash, "")
+}
+
+func (app *TestApplication) Query(reqQuery types.RequestQuery) types.ResponseQuery {
+	app.QueryCalls.Notify()
+	switch reqQuery.Path {
+	case "hash":
+		return types.ResponseQuery{Value: []byte(cmn.Fmt("%v", app.hashCount))}
+	case "tx":
+		return types.ResponseQuery{Value: []byte(cmn.Fmt("%v", app.txCount))}
+	default:
+		return types.ResponseQuery{Log: cmn.Fmt("Invalid query path. Expected hash or tx, got %v", reqQuery.Path)}
+	}
+}
+
+func (app *TestApplication) EndBlock(height uint64) (resEndBlock types.ResponseEndBlock) {
+	app.EndBlockCalls.Notify(height)
+	return types.ResponseEndBlock{}
+}

--- a/use_cases_test.go
+++ b/use_cases_test.go
@@ -2,6 +2,7 @@ package abciproxy
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,9 +13,10 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type UseCaseSuite struct {
-	testHome    string
-	genesisPath string
-	nodes       []*BCNode
+	testHome     string
+	genesisPath  string
+	nodes        []*BCNode
+	startedNodes []*BCNode
 }
 
 var _ = Suite(&UseCaseSuite{})
@@ -23,7 +25,10 @@ var _ = Suite(&UseCaseSuite{})
 func (s *UseCaseSuite) SetUpGenesis(validators, observers []*BCNode) error {
 
 	//TODO: create a new blockchain, via the correct genesis file, with the right information
-	return NotYetImplemented()
+	func() {
+		log.Printf("W A R N I N G\nBlockchain are independant and does not share the same genesis file, please implement %s", CallerName())
+	}()
+	return nil
 }
 
 func (s *UseCaseSuite) SetUpSuite(c *C) {
@@ -38,10 +43,7 @@ func (s *UseCaseSuite) SetUpSuite(c *C) {
 	//TODO: create the 4 required node
 	s.nodes = nil
 	for i := 0; i < 4; i++ {
-		//create a new home directory for the node
-		nDir, err := ioutil.TempDir(s.testHome, "blockchain_node")
-		c.Assert(err, IsNil)
-		n, err := NewBCNode(BCNodeID(i), s.genesisPath, nDir)
+		n, err := NewBCNode(BCNodeID(i), s.genesisPath, s.testHome)
 		c.Assert(err, IsNil, Commentf("Could not create node %d: %s", i, err))
 		s.nodes = append(s.nodes, n)
 	}
@@ -57,28 +59,48 @@ func (s *UseCaseSuite) SetUpTest(c *C) {
 	//create a new blockchain to work with
 	err := s.SetUpGenesis(s.nodes[0:3], s.nodes[3:])
 	c.Assert(err, IsNil, Commentf("Could not setup genesis file:%s", err))
+}
 
+func (s *UseCaseSuite) StartNodes(c *C) {
+	log.Printf("Starting up blockchain nodes")
 	for _, n := range s.nodes {
-		err = n.Start()
+		err := n.Start()
 		c.Assert(err, IsNil)
+		s.startedNodes = append(s.startedNodes, n)
 	}
 }
 
 func (s *UseCaseSuite) TearDownTest(c *C) {
-	for _, n := range s.nodes {
+	log.Printf("Closing up started blockchain nodes")
+	for _, n := range s.startedNodes {
 		err := n.Stop()
 		c.Assert(err, IsNil)
 	}
 }
 
-func (s *UseCaseSuite) TestChangeObserverToValidator(c *C) {
-	//the 4 chain are started
+func (s *UseCaseSuite) TestCanRunSimpleCounterInOneNode(c *C) {
 
+	//expect 10 calls
+	s.nodes[0].testApplication.EndBlockCalls.ExpectCall(10)
+
+	err := s.nodes[0].Start()
+	c.Assert(err, IsNil)
+
+	s.nodes[0].testApplication.EndBlockCalls.WaitForExpected()
+
+	//for debugging purposes
+	log.Printf("\n---tendermint output---\n%s\n---proxy output---\n%s\n---app output---\n%s",
+		s.nodes[0].tmNodeOutput.String(),
+		s.nodes[0].proxyOutput.String(),
+		s.nodes[0].appOutput.String())
 	//specify that when height = 100, we should change observer node 3 to validators
 
+	//manually closing up the node
+	err = s.nodes[0].Stop()
+	c.Assert(err, IsNil)
 }
 
-func (s *UseCaseSuite) TestAddValidatorOnTheFly(c *C) {
-	//the 4 chain are started
+// func (s *UseCaseSuite) TestAddValidatorOnTheFly(c *C) {
+// 	// the 4 chain are started
 
-}
+// }

--- a/use_cases_test.go
+++ b/use_cases_test.go
@@ -88,7 +88,7 @@ func (s *UseCaseSuite) TearDownSuite(c *C) {
 func (s *UseCaseSuite) SetUpTest(c *C) {
 	s.nodes = nil
 	for i := 0; i < TotalTestNode; i++ {
-		n, err := NewBCNode(BCNodeID(i), s.genesisPath, s.testHome)
+		n, err := NewBCNode(BCNodeID(i), s.testHome)
 		c.Assert(err, IsNil, Commentf("Could not create node %d: %s", i, err))
 		s.nodes = append(s.nodes, n)
 	}
@@ -212,7 +212,7 @@ func (s *UseCaseSuite) TestCanMakeObserverAValidator(c *C) {
 
 	s.nodes[0].testApplication.EndBlockCalls.WaitForExpected()
 	for _, n := range s.nodes {
-		n.proxy.ChangeValidator(validators, 10)
+		n.proxy.ChangeValidators(validators, 10)
 		n.testApplication.EndBlockCalls.ExpectCall(4)
 	}
 

--- a/use_cases_test.go
+++ b/use_cases_test.go
@@ -1,75 +1,142 @@
 package abciproxy
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/tendermint/tendermint/types"
+
 	. "gopkg.in/check.v1"
 )
+
+// Number of node to instantiate for tests
+const TotalTestNode = 5
 
 func Test(t *testing.T) { TestingT(t) }
 
 type UseCaseSuite struct {
-	testHome     string
-	genesisPath  string
-	nodes        []*BCNode
-	startedNodes []*BCNode
+	testHome      string
+	genesisPath   string
+	nodes         []*BCNode
+	startedNodes  []*BCNode
+	genesisFiles  map[BCNodeID]*types.GenesisDoc
+	genesisNumber int
 }
 
 var _ = Suite(&UseCaseSuite{})
 
-// SetUpGenesis setup a new genesis file for working on a new blockchain. Validators are the ID of the validators with a weight of one, and observers are the one with a weight of 1
+// SetUpGenesis setup a new genesis file for working on a new
+// blockchain. Validators are the ID of the validators with a weight
+// of one, and observers are the one with a weight of 1
 func (s *UseCaseSuite) SetUpGenesis(validators, observers []*BCNode) error {
+	s.genesisNumber++
+	firstGenesis := s.genesisFiles[s.nodes[0].ID]
 
-	//TODO: create a new blockchain, via the correct genesis file, with the right information
-	func() {
-		log.Printf("W A R N I N G\nBlockchain are independant and does not share the same genesis file, please implement %s", CallerName())
-	}()
-	return nil
+	//merge all of them in a single nice genesis file
+	newGenesis := types.GenesisDoc{
+		GenesisTime: firstGenesis.GenesisTime,
+		ChainID:     firstGenesis.ChainID + fmt.Sprintf("-test-%d", s.genesisNumber),
+		AppHash:     firstGenesis.AppHash,
+	}
+
+	for _, n := range validators {
+		validator := s.genesisFiles[n.ID].Validators[0]
+		newGenesis.Validators = append(newGenesis.Validators, validator)
+	}
+
+	for _, n := range observers {
+		validator := s.genesisFiles[n.ID].Validators[0]
+		validator.Amount = 0
+		newGenesis.Validators = append(newGenesis.Validators, validator)
+	}
+
+	return newGenesis.SaveAs(s.genesisPath)
 }
 
+// SetUpSuite creates the temporary structure for all nodes we requires
 func (s *UseCaseSuite) SetUpSuite(c *C) {
 	var err error
-	//we create a new tendermint structure for the test
 
+	// everything goes in a nice temporary directory
 	s.testHome, err = ioutil.TempDir("", "abci_proxy_test")
 	c.Assert(err, IsNil, Commentf("Cannot create tmpdir: %s", err))
 
 	s.genesisPath = filepath.Join(s.testHome, "genesis.json")
 
-	//TODO: create the 4 required node
 	s.nodes = nil
-	for i := 0; i < 4; i++ {
+	for i := 0; i < TotalTestNode; i++ {
 		n, err := NewBCNode(BCNodeID(i), s.genesisPath, s.testHome)
 		c.Assert(err, IsNil, Commentf("Could not create node %d: %s", i, err))
 		s.nodes = append(s.nodes, n)
 	}
 
+	//gather all nodes genesis
+	s.genesisFiles = make(map[BCNodeID]*types.GenesisDoc)
+	for _, n := range s.nodes {
+		gPath := filepath.Join(n.WorkingDir(), "genesis.json")
+		gDoc, err := types.GenesisDocFromFile(gPath)
+		c.Assert(err, IsNil)
+		s.genesisFiles[n.ID] = gDoc
+
+	}
+
+	s.genesisNumber = 0
+
+	//ugly way to specify the genesis, sorry
+	configToml := `# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+proxy_app = "tcp://127.0.0.1:46658"
+moniker = "anonymous"
+fast_sync = true
+db_backend = "leveldb"
+log_level = "state:info,*:error"
+genesis_file = "` + s.genesisPath + `"
+
+[rpc]
+laddr = "tcp://0.0.0.0:46657"
+
+[p2p]
+laddr = "tcp://0.0.0.0:46656"
+seeds = ""
+`
+	for _, n := range s.nodes {
+		configPath := filepath.Join(n.WorkingDir(), "config.toml")
+		err := ioutil.WriteFile(configPath, []byte(configToml), 0644)
+		c.Assert(err, IsNil)
+	}
+
 }
 
+// TearDownSuite cleans all temporary data
 func (s *UseCaseSuite) TearDownSuite(c *C) {
 	err := os.RemoveAll(s.testHome)
 	c.Check(err, IsNil, Commentf("cannot remove temporary directory: %s", err))
 }
 
+// SetUpTest creates a new single genesis file for each of the test
 func (s *UseCaseSuite) SetUpTest(c *C) {
-	//create a new blockchain to work with
-	err := s.SetUpGenesis(s.nodes[0:3], s.nodes[3:])
+	//create a new blockchain to work with first 4 nodes validators and last observer
+	err := s.SetUpGenesis(s.nodes[0:(TotalTestNode-1)], s.nodes[(TotalTestNode-1):])
 	c.Assert(err, IsNil, Commentf("Could not setup genesis file:%s", err))
 }
 
+// StartNodes starts all the instantiated nodes and mark them to be
+// stopped by TearDownTest. You have to call it manually in your test
 func (s *UseCaseSuite) StartNodes(c *C) {
 	log.Printf("Starting up blockchain nodes")
 	for _, n := range s.nodes {
-		err := n.Start()
+		err := n.Start(s.nodes)
 		c.Assert(err, IsNil)
 		s.startedNodes = append(s.startedNodes, n)
 	}
 }
 
+// TearDownTest ensure that after every test, we stop all the node which have been started with StartNodes
 func (s *UseCaseSuite) TearDownTest(c *C) {
 	log.Printf("Closing up started blockchain nodes")
 	for _, n := range s.startedNodes {
@@ -78,29 +145,24 @@ func (s *UseCaseSuite) TearDownTest(c *C) {
 	}
 }
 
-func (s *UseCaseSuite) TestCanRunSimpleCounterInOneNode(c *C) {
+func (s *UseCaseSuite) TestCanRunSimpleCounterInAllNode(c *C) {
+	// remarks: this test is for a single node (nodes[0]) we start and stop it manually
 
 	//expect 10 calls
-	s.nodes[0].testApplication.EndBlockCalls.ExpectCall(10)
+	for _, n := range s.nodes {
+		n.testApplication.EndBlockCalls.ExpectCall(10)
+	}
 
-	err := s.nodes[0].Start()
-	c.Assert(err, IsNil)
+	s.StartNodes(c)
 
-	s.nodes[0].testApplication.EndBlockCalls.WaitForExpected()
-
-	//for debugging purposes
-	log.Printf("\n---tendermint output---\n%s\n---proxy output---\n%s\n---app output---\n%s",
-		s.nodes[0].tmNodeOutput.String(),
-		s.nodes[0].proxyOutput.String(),
-		s.nodes[0].appOutput.String())
+	for _, n := range s.nodes {
+		n.testApplication.EndBlockCalls.WaitForExpected()
+		//for debugging purposes
+		log.Printf("\n---tendermint output [Node %d] ---\n%s\n---proxy output  [Node %d] ---\n%s\n---app output  [Node %d]---\n%s",
+			n.ID, n.tmNodeOutput.String(),
+			n.ID, n.proxyOutput.String(),
+			n.ID, n.appOutput.String())
+	}
 	//specify that when height = 100, we should change observer node 3 to validators
 
-	//manually closing up the node
-	err = s.nodes[0].Stop()
-	c.Assert(err, IsNil)
 }
-
-// func (s *UseCaseSuite) TestAddValidatorOnTheFly(c *C) {
-// 	// the 4 chain are started
-
-// }

--- a/use_cases_test.go
+++ b/use_cases_test.go
@@ -1,0 +1,84 @@
+package abciproxy
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type UseCaseSuite struct {
+	testHome    string
+	genesisPath string
+	nodes       []*BCNode
+}
+
+var _ = Suite(&UseCaseSuite{})
+
+// SetUpGenesis setup a new genesis file for working on a new blockchain. Validators are the ID of the validators with a weight of one, and observers are the one with a weight of 1
+func (s *UseCaseSuite) SetUpGenesis(validators, observers []*BCNode) error {
+
+	//TODO: create a new blockchain, via the correct genesis file, with the right information
+	return NotYetImplemented()
+}
+
+func (s *UseCaseSuite) SetUpSuite(c *C) {
+	var err error
+	//we create a new tendermint structure for the test
+
+	s.testHome, err = ioutil.TempDir("", "abci_proxy_test")
+	c.Assert(err, IsNil, Commentf("Cannot create tmpdir: %s", err))
+
+	s.genesisPath = filepath.Join(s.testHome, "genesis.json")
+
+	//TODO: create the 4 required node
+	s.nodes = nil
+	for i := 0; i < 4; i++ {
+		//create a new home directory for the node
+		nDir, err := ioutil.TempDir(s.testHome, "blockchain_node")
+		c.Assert(err, IsNil)
+		n, err := NewBCNode(BCNodeID(i), s.genesisPath, nDir)
+		c.Assert(err, IsNil, Commentf("Could not create node %d: %s", i, err))
+		s.nodes = append(s.nodes, n)
+	}
+
+}
+
+func (s *UseCaseSuite) TearDownSuite(c *C) {
+	err := os.RemoveAll(s.testHome)
+	c.Check(err, IsNil, Commentf("cannot remove temporary directory: %s", err))
+}
+
+func (s *UseCaseSuite) SetUpTest(c *C) {
+	//create a new blockchain to work with
+	err := s.SetUpGenesis(s.nodes[0:3], s.nodes[3:])
+	c.Assert(err, IsNil, Commentf("Could not setup genesis file:%s", err))
+
+	for _, n := range s.nodes {
+		err = n.Start()
+		c.Assert(err, IsNil)
+	}
+}
+
+func (s *UseCaseSuite) TearDownTest(c *C) {
+	for _, n := range s.nodes {
+		err := n.Stop()
+		c.Assert(err, IsNil)
+	}
+}
+
+func (s *UseCaseSuite) TestChangeObserverToValidator(c *C) {
+	//the 4 chain are started
+
+	//specify that when height = 100, we should change observer node 3 to validators
+
+}
+
+func (s *UseCaseSuite) TestAddValidatorOnTheFly(c *C) {
+	//the 4 chain are started
+
+}

--- a/use_cases_test.go
+++ b/use_cases_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	abcitypes "github.com/tendermint/abci/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/core/types"
+	rpc "github.com/tendermint/tendermint/rpc/lib/client"
 	"github.com/tendermint/tendermint/types"
 
 	. "gopkg.in/check.v1"
@@ -33,7 +36,8 @@ var _ = Suite(&UseCaseSuite{})
 // blockchain. Validators are the ID of the validators with a weight
 // of one, and observers are the one with a weight of 1
 func (s *UseCaseSuite) SetUpGenesis(validators, observers []*BCNode) error {
-	s.genesisNumber++
+	s.genesisNumber = s.genesisNumber + 1
+
 	firstGenesis := s.genesisFiles[s.nodes[0].ID]
 
 	//merge all of them in a single nice genesis file
@@ -54,6 +58,8 @@ func (s *UseCaseSuite) SetUpGenesis(validators, observers []*BCNode) error {
 		newGenesis.Validators = append(newGenesis.Validators, validator)
 	}
 
+	os.Remove(s.genesisPath)
+
 	return newGenesis.SaveAs(s.genesisPath)
 }
 
@@ -61,12 +67,25 @@ func (s *UseCaseSuite) SetUpGenesis(validators, observers []*BCNode) error {
 func (s *UseCaseSuite) SetUpSuite(c *C) {
 	var err error
 
+	s.genesisNumber = 0
+
 	// everything goes in a nice temporary directory
 	s.testHome, err = ioutil.TempDir("", "abci_proxy_test")
 	c.Assert(err, IsNil, Commentf("Cannot create tmpdir: %s", err))
 
 	s.genesisPath = filepath.Join(s.testHome, "genesis.json")
 
+}
+
+// TearDownSuite cleans all temporary data
+func (s *UseCaseSuite) TearDownSuite(c *C) {
+	err := os.RemoveAll(s.testHome)
+	c.Check(err, IsNil, Commentf("cannot remove temporary directory: %s", err))
+	os.Remove(s.testHome)
+}
+
+// SetUpTest creates a new single genesis file for each of the test
+func (s *UseCaseSuite) SetUpTest(c *C) {
 	s.nodes = nil
 	for i := 0; i < TotalTestNode; i++ {
 		n, err := NewBCNode(BCNodeID(i), s.genesisPath, s.testHome)
@@ -83,8 +102,6 @@ func (s *UseCaseSuite) SetUpSuite(c *C) {
 		s.genesisFiles[n.ID] = gDoc
 
 	}
-
-	s.genesisNumber = 0
 
 	//ugly way to specify the genesis, sorry
 	configToml := `# This is a TOML config file.
@@ -110,16 +127,6 @@ seeds = ""
 		c.Assert(err, IsNil)
 	}
 
-}
-
-// TearDownSuite cleans all temporary data
-func (s *UseCaseSuite) TearDownSuite(c *C) {
-	err := os.RemoveAll(s.testHome)
-	c.Check(err, IsNil, Commentf("cannot remove temporary directory: %s", err))
-}
-
-// SetUpTest creates a new single genesis file for each of the test
-func (s *UseCaseSuite) SetUpTest(c *C) {
 	//create a new blockchain to work with first 4 nodes validators and last observer
 	err := s.SetUpGenesis(s.nodes[0:(TotalTestNode-1)], s.nodes[(TotalTestNode-1):])
 	c.Assert(err, IsNil, Commentf("Could not setup genesis file:%s", err))
@@ -142,7 +149,11 @@ func (s *UseCaseSuite) TearDownTest(c *C) {
 	for _, n := range s.startedNodes {
 		err := n.Stop()
 		c.Assert(err, IsNil)
+		err = os.RemoveAll(n.WorkingDir())
+		c.Assert(err, IsNil)
 	}
+
+	s.startedNodes = make([]*BCNode, 0, len(s.nodes))
 }
 
 func (s *UseCaseSuite) TestCanRunSimpleCounterInAllNode(c *C) {
@@ -158,11 +169,98 @@ func (s *UseCaseSuite) TestCanRunSimpleCounterInAllNode(c *C) {
 	for _, n := range s.nodes {
 		n.testApplication.EndBlockCalls.WaitForExpected()
 		//for debugging purposes
-		log.Printf("\n---tendermint output [Node %d] ---\n%s\n---proxy output  [Node %d] ---\n%s\n---app output  [Node %d]---\n%s",
-			n.ID, n.tmNodeOutput.String(),
-			n.ID, n.proxyOutput.String(),
-			n.ID, n.appOutput.String())
+
+		// log.Printf("[Node %d Calls]\nInfo: %d\nCommit: %d\nSetoption: %d\nDeliverTx: %d\nCheckTx: %d\nQuery %d\nEndBlock: %d", n.ID,
+		// 	len(n.testApplication.InfoCalls.Calls),
+		// 	len(n.testApplication.CommitCalls.Calls),
+		// 	len(n.testApplication.SetOptionCalls.Calls),
+		// 	len(n.testApplication.DeliverTxCalls.Calls),
+		// 	len(n.testApplication.CheckTxCalls.Calls),
+		// 	len(n.testApplication.QueryCalls.Calls),
+		// 	len(n.testApplication.EndBlockCalls.Calls),
+		// )
+
+		//ensure all node reached height 10
+		endBlockCalls := n.testApplication.EndBlockCalls.Calls
+		lastHeight := endBlockCalls[len(endBlockCalls)-1][0].(uint64)
+		c.Check(lastHeight >= uint64(10), Equals, true, Commentf("node %d reached %d", n.ID, lastHeight))
+
 	}
-	//specify that when height = 100, we should change observer node 3 to validators
+
+}
+
+func (s *UseCaseSuite) TestCanMakeObserverAValidator(c *C) {
+
+	//wait the block 10 on first node
+	s.nodes[0].testApplication.EndBlockCalls.ExpectCall(5)
+
+	observerKey := s.genesisFiles[TotalTestNode-1].Validators[0].PubKey
+
+	s.StartNodes(c)
+
+	validators := make([]*abcitypes.Validator, 0, len(s.nodes))
+
+	//build the new list of Validator
+	for _, g := range s.genesisFiles {
+		c.Assert(len(g.Validators), Equals, 1)
+		v := &abcitypes.Validator{
+			PubKey: g.Validators[0].PubKey.Bytes(),
+			Power:  10,
+		}
+		validators = append(validators, v)
+	}
+
+	s.nodes[0].testApplication.EndBlockCalls.WaitForExpected()
+	for _, n := range s.nodes {
+		n.proxy.ChangeValidator(validators, 10)
+		n.testApplication.EndBlockCalls.ExpectCall(4)
+	}
+
+	//we check for the next 2 block, the validator does not change
+	for _, n := range s.nodes {
+		n.testApplication.EndBlockCalls.WaitForExpected()
+
+		//we check that all the validator have the correct voting power, aka 10 except for the observer
+		client := rpc.NewJSONRPCClient(fmt.Sprintf("http://localhost:%d", n.RPCPort()))
+
+		res := new(rpctypes.ResultValidators)
+		_, err := client.Call("validators", map[string]interface{}{}, res)
+		if c.Check(err, IsNil) == false {
+			continue
+		}
+		for _, v := range res.Validators {
+			expectedVotingPower := int64(10)
+			if v.PubKey == observerKey {
+				expectedVotingPower = int64(0)
+			}
+
+			c.Check(v.VotingPower, Equals, expectedVotingPower)
+		}
+
+		n.testApplication.EndBlockCalls.ExpectCall(2)
+	}
+
+	//we check that after block 11 all validators are here
+	for _, n := range s.nodes {
+		n.testApplication.EndBlockCalls.WaitForExpected()
+
+		//ensure all node reached height 11
+		endBlockCalls := n.testApplication.EndBlockCalls.Calls
+		lastHeight := endBlockCalls[len(endBlockCalls)-1][0].(uint64)
+		c.Check(lastHeight >= uint64(11), Equals, true, Commentf("node %d reached %d", n.ID, lastHeight))
+
+		//we check that all the validator have the correct voting power
+
+		client := rpc.NewJSONRPCClient(fmt.Sprintf("http://localhost:%d", n.RPCPort()))
+
+		res := new(rpctypes.ResultValidators)
+		_, err := client.Call("validators", map[string]interface{}{}, res)
+		if c.Check(err, IsNil) == false {
+			continue
+		}
+		for _, v := range res.Validators {
+			c.Check(v.VotingPower, Equals, int64(10))
+		}
+	}
 
 }

--- a/utils.go
+++ b/utils.go
@@ -1,16 +1,25 @@
 package abciproxy
 
 import (
+	"fmt"
 	"runtime"
 
 	tmlog "github.com/tendermint/tmlibs/log"
 )
 
-func LogCall(logger tmlog.Logger, keyvals ...interface{}) {
-	fpc, _, _, ok := runtime.Caller(1)
+func CallerName() string {
+	fpc, _, _, ok := runtime.Caller(2)
 	if ok == false {
 		panic("Could not found caller")
 	}
 	fun := runtime.FuncForPC(fpc)
-	logger.Debug(fun.Name(), keyvals...)
+	return fun.Name()
+}
+
+func LogCall(logger tmlog.Logger, keyvals ...interface{}) {
+	logger.Debug(CallerName(), keyvals...)
+}
+
+func NotYetImplemented() error {
+	return fmt.Errorf("%s is not et implemented", CallerName())
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,51 @@
+package abciproxy
+
+import "sync"
+
+//slow and super ugly, but really its a sprint
+type InterceptedMethod struct {
+	Name          string
+	Calls         [][]interface{}
+	wg            sync.WaitGroup
+	wgLock        sync.Mutex
+	expectedCalls int
+	currentCalls  int
+}
+
+func NewInterceptedMethod(name string) InterceptedMethod {
+	return InterceptedMethod{
+		Name:   name,
+		Calls:  nil,
+		wg:     sync.WaitGroup{},
+		wgLock: sync.Mutex{},
+	}
+}
+
+func (im *InterceptedMethod) Notify(args ...interface{}) {
+	im.Calls = append(im.Calls, append([]interface{}{}, args...))
+
+	im.wgLock.Lock()
+	defer im.wgLock.Unlock()
+	if im.expectedCalls == 0 {
+		return
+	}
+	im.currentCalls++
+	if im.expectedCalls == im.currentCalls {
+		im.wg.Done()
+		im.expectedCalls = 0
+	}
+
+}
+
+func (im *InterceptedMethod) ExpectCall(N int) {
+	im.wgLock.Lock()
+	defer im.wgLock.Unlock()
+
+	im.expectedCalls = N
+	im.currentCalls = 0
+	im.wg.Add(1)
+}
+
+func (im *InterceptedMethod) WaitForExpected() {
+	im.wg.Wait()
+}


### PR DESCRIPTION
In order to test the proxy, we need our own, little orchestration, that is not actually spawning services over several computer / virtual machine, but spawning X instances on the local computer

I am using here go-check to set up our test environment by configuring and spawing multiple BlockChainNode (aka tendermint node+ application + our proxy)

The application will be a very simple application, similar to the counter one, with the exception that I trace all the calls to from the tendermint node, and we can wait for a certain number of call to happen (aka wait for the application to have 10 times EndBlock called)

With such tools it would be easy to setup nicely test on a single computer to test internally our proxy

